### PR TITLE
fix(ci): resolve GHCR publish permission and consolidate build job 🐛

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,30 @@ jobs:
     needs: [test, helm-lint]
     permissions:
       contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64
+
+  publish:
+    name: Publish to GHCR
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
       packages: write
 
     steps:
@@ -85,7 +109,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
-        if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -117,7 +140,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
         with:
           images: ghcr.io/klazomenai/tide
           tags: |
-            type=raw,value=${{ steps.get_version.outputs.version }}
+            type=raw,value=${{ steps.get_version.outputs.version }},enable={{is_default_branch}}
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=sha-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
     needs: [test, helm-lint]
     permissions:
       contents: read
+      packages: write
 
     steps:
       - name: Checkout repository
@@ -83,58 +84,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Extract version from CHANGELOG
-        id: get_version
-        run: |
-          if [ -n "${{ github.event.inputs.version }}" ]; then
-            VERSION="${{ github.event.inputs.version }}"
-          else
-            VERSION=$(grep -m 1 -oP '\[\K[0-9]+\.[0-9]+\.[0-9]+(?=\])' CHANGELOG.md || echo "0.1.0")
-          fi
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "Building version: ${VERSION}"
-
-      - name: Build Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: false
-          tags: ghcr.io/klazomenai/tide:test
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          platforms: linux/amd64
-          outputs: type=docker,dest=/tmp/tide-image.tar
-
-      - name: Upload image artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: tide-image
-          path: /tmp/tide-image.tar
-          retention-days: 1
-
-  publish:
-    name: Publish to GHCR
-    runs-on: ubuntu-latest
-    needs: build
-    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Download image artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: tide-image
-          path: /tmp
-
-      - name: Load Docker image
-        run: docker load --input /tmp/tide-image.tar
-
       - name: Log in to GitHub Container Registry
+        if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -149,14 +100,26 @@ jobs:
           else
             VERSION=$(grep -m 1 -oP '\[\K[0-9]+\.[0-9]+\.[0-9]+(?=\])' CHANGELOG.md || echo "0.1.0")
           fi
+          echo "Building version: ${VERSION}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
-      - name: Tag and push image
-        if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
-        run: |
-          docker tag ghcr.io/klazomenai/tide:test ghcr.io/klazomenai/tide:${{ steps.get_version.outputs.version }}
-          docker tag ghcr.io/klazomenai/tide:test ghcr.io/klazomenai/tide:latest
-          docker tag ghcr.io/klazomenai/tide:test ghcr.io/klazomenai/tide:sha-${{ github.sha }}
-          docker push ghcr.io/klazomenai/tide:${{ steps.get_version.outputs.version }}
-          docker push ghcr.io/klazomenai/tide:latest
-          docker push ghcr.io/klazomenai/tide:sha-${{ github.sha }}
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/klazomenai/tide
+          tags: |
+            type=raw,value=${{ steps.get_version.outputs.version }}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=sha-
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ COPY src/ ./src/
 RUN adduser -D -u 10001 appuser && chown -R appuser /app
 USER appuser
 
+LABEL org.opencontainers.image.source="https://github.com/Klazomenai/tide"
+
 ENV PYTHONPATH=/app/src
 ENV PYTHONUNBUFFERED=1
 


### PR DESCRIPTION
## Summary

- Split CI into separate `build` (read-only) and `publish` (packages:write) jobs for least-privilege token scope
- Replace artifact-passing pattern (TAR upload/download) with `docker/build-push-action`'s native push
- Add `docker/metadata-action@v5` for declarative tag generation (version, `latest` on default branch, `sha-` prefix)
- Add OCI source label to Dockerfile for GHCR auto-linking
- PR builds are build-only with read-only permissions; publish only runs on `main` and `workflow_dispatch`

## Root cause

An orphaned GHCR package entry (created by a partial push on the original failed CI run) blocked all subsequent `GITHUB_TOKEN` pushes. Deleting the orphaned package and configuring "Manage Actions access" on the recreated package resolved the permission issue. See #10 for full analysis.

## Verification

- [x] `workflow_dispatch` on fix branch — build + publish both succeed (run 22138875244)
- [x] `GITHUB_TOKEN` works alone (no PAT fallback needed)
- [x] PR CI run builds but does NOT publish (publish job skipped on `pull_request`)
- [ ] After merge, push-to-main publishes with `latest` tag

Refs #10